### PR TITLE
[Magento] NB Collector proxy

### DIFF
--- a/Northbeam/PixelForwarder/Api/ForwarderInterface.php
+++ b/Northbeam/PixelForwarder/Api/ForwarderInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Northbeam\PixelForwarder\Api;
+
+interface ForwarderInterface
+{
+    /**
+     * Proxies the given data to another service.
+     * 
+     * @api
+     * @return mixed The response from the other service.
+     */
+    public function proxy();
+}

--- a/Northbeam/PixelForwarder/Controller/PixelRequestProcessor.php
+++ b/Northbeam/PixelForwarder/Controller/PixelRequestProcessor.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Northbeam\PixelForwarder\Controller;
+
+use Magento\Webapi\Controller\Rest\RequestProcessorInterface;
+use Magento\Framework\Webapi\Rest\Request;
+use Magento\Framework\Webapi\Rest\Response as RestResponse;
+use \Magento\Webapi\Controller\Rest\InputParamsResolver;
+use \Magento\Framework\Webapi\ServiceOutputProcessor;
+use \Magento\Framework\Webapi\Rest\Response\FieldsFilter;
+use \Magento\Framework\App\DeploymentConfig;
+use \Magento\Framework\ObjectManagerInterface;
+use \Psr\Log\LoggerInterface;
+
+class PixelRequestProcessor implements RequestProcessorInterface
+{
+    const PROCESSOR_PATH = "nb-collector";
+
+    /**
+     * @var RestResponse
+     */
+    private $response;
+
+    /**
+     * @var InputParamsResolver
+     */
+    private $inputParamsResolver;
+
+    /**
+     * @var ServiceOutputProcessor
+     */
+    private $serviceOutputProcessor;
+
+    /**
+     * @var FieldsFilter
+     */
+    private $fieldsFilter;
+
+    /**
+     * @var \Magento\Framework\App\DeploymentConfig
+     */
+    private $deploymentConfig;
+
+    /**
+     * @var ObjectManagerInterface
+     */
+    private $objectManager;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * Initial dependencies
+     *
+     * @param FrameworkResponse $response
+     * @param WebapiInputParamsResolver $inputParamsResolver
+     * @param MagentoServiceOutputProcessor $serviceOutputProcessor
+     * @param WebapiFieldsFilter $fieldsFilter
+     * @param MagentoDeploymentConfig $deploymentConfig
+     * @param ObjectManagerInterface $objectManager
+     */
+    public function __construct(
+        RestResponse $response,
+        InputParamsResolver $inputParamsResolver,
+        ServiceOutputProcessor $serviceOutputProcessor,
+        FieldsFilter $fieldsFilter,
+        DeploymentConfig $deploymentConfig,
+        ObjectManagerInterface $objectManager
+    ) {
+        $this->response = $response;
+        $this->inputParamsResolver = $inputParamsResolver;
+        $this->serviceOutputProcessor = $serviceOutputProcessor;
+        $this->fieldsFilter = $fieldsFilter;
+        $this->deploymentConfig = $deploymentConfig;
+        $this->objectManager = $objectManager;
+        $this->logger = $objectManager->get(LoggerInterface::class);
+    }
+
+    /**
+     *  {@inheritdoc}
+     */
+    public function process(Request $request)
+    {
+        // $inputParams = $this->inputParamsResolver->resolve();
+        $inputParams = $this->inputParamsResolver->getInputData();
+        $route = $this->inputParamsResolver->getRoute();
+        $serviceMethodName = $route->getServiceMethod();
+        $serviceClassName = $route->getServiceClass();
+        $service = $this->objectManager->get($serviceClassName);
+
+        /**
+         * @var \Magento\Framework\Api\AbstractExtensibleObject $outputData
+         */
+        $outputData = call_user_func_array([$service, $serviceMethodName], []);
+        $this->response->prepareResponse($outputData);
+    }
+
+    /**
+     *  {@inheritdoc}
+     */
+    public function canProcess(Request $request)
+    {
+        if (strpos(ltrim($request->getPathInfo(), '/'), self::PROCESSOR_PATH) === 0) {
+            // if request's path starts with 'nb-collector' then we can process it
+            return true;
+        }
+        return false;
+    }
+}

--- a/Northbeam/PixelForwarder/Controller/PixelRequestProcessor.php
+++ b/Northbeam/PixelForwarder/Controller/PixelRequestProcessor.php
@@ -86,7 +86,7 @@ class PixelRequestProcessor implements RequestProcessorInterface
     public function process(Request $request)
     {
         // $inputParams = $this->inputParamsResolver->resolve();
-        $inputParams = $this->inputParamsResolver->getInputData();
+        // $inputParams = $this->inputParamsResolver->getInputData();
         $route = $this->inputParamsResolver->getRoute();
         $serviceMethodName = $route->getServiceMethod();
         $serviceClassName = $route->getServiceClass();
@@ -96,7 +96,16 @@ class PixelRequestProcessor implements RequestProcessorInterface
          * @var \Magento\Framework\Api\AbstractExtensibleObject $outputData
          */
         $outputData = call_user_func_array([$service, $serviceMethodName], []);
-        $this->response->prepareResponse($outputData);
+
+        $response_code = $outputData['response_code'];
+        $response_data = $outputData['response_data'];
+        $response_headers = $outputData['response_headers'];
+
+        $this->setHeaders($response_headers);
+        $this->response->setHttpResponseCode($response_code);
+        $this->response->setMimeType('text/plain');
+        $this->response->setBody($response_data);
+        $this->response->sendResponse();
     }
 
     /**
@@ -109,5 +118,12 @@ class PixelRequestProcessor implements RequestProcessorInterface
             return true;
         }
         return false;
+    }
+
+    protected function setHeaders($headers)
+    {
+        foreach($headers as $key => $value) {
+            $this->response->setHeader($key, $value, true);
+        }
     }
 }

--- a/Northbeam/PixelForwarder/Model/Forwarder.php
+++ b/Northbeam/PixelForwarder/Model/Forwarder.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace Northbeam\PixelForwarder\Model;
+
+use Magento\Framework\Webapi\Rest\Request;
+use Northbeam\PixelForwarder\Api\ForwarderInterface;
+use Magento\Framework\App\ObjectManager;
+use Psr\Log\LoggerInterface;
+
+class Forwarder implements ForwarderInterface
+{
+    protected Request $request;
+    protected LoggerInterface $logger;
+    protected const COLLECTOR_URL = 'https://i.northbeam.io/nb-collector';
+    protected const REQUEST_HEADERS = ['x-forwarded-proto', 'x-forwarded-host', 'x-forwarded-for', 'sec-fetch-site', 'sec-fetch-mode', 'sec-fetch-dest', 'sec-ch-ua-platform', 'sec-ch-ua-mobile', 'sec-ch-ua', 'referer', 'origin', 'cookie', 'content-type', 'accept-language', 'accept-encoding', 'accept', 'content-length', 'user-agent'];
+
+    public function __construct(Request $request)
+    {
+        $this->request = $request;
+
+        $object_manager = ObjectManager::getInstance();
+        $this->logger = $object_manager->get(LoggerInterface::class);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function proxy()
+    {
+        $request = $this->request;
+        $body = $request->getRequestData();
+        $headers = $this->mapHeaderKeysCurl($this->getRequestHeaders());
+
+        $this->logger->info("Proxying request to another service");
+
+        $response_headers = [];
+        $curl = curl_init();
+        curl_setopt_array($curl, array(
+            CURLOPT_URL => self::COLLECTOR_URL,
+            CURLOPT_RETURNTRANSFER => true, // return response as string
+            CURLOPT_CUSTOMREQUEST => 'POST',
+            CURLOPT_POSTFIELDS => $body,
+            CURLOPT_HTTPHEADER => $headers,
+            CURLOPT_HEADER => true, // include headers in response
+            CURLOPT_HEADERFUNCTION => function ($curl, $header) use (&$response_headers) { // callback for response headers
+                return $this->processResponseHeader($curl, $header, $response_headers);
+            }
+        ));
+        $response = curl_exec($curl);
+
+        $header_size = curl_getinfo($curl, CURLINFO_HEADER_SIZE);
+        $response_body = substr($response, $header_size); // remove headers from response
+        $response_code = curl_getinfo($curl, CURLINFO_HTTP_CODE);
+        curl_close($curl);
+
+
+        return [
+            "request_data" => $body,
+            "request_headers" => $headers,
+            "response_code" => $response_code,
+            "response_data" => $response_body,
+            "response_headers" => $response_headers,
+        ];
+    }
+
+    /**
+     * Returns an array of request headers.
+     *
+     * Magento's Request object has a 'getHeaders' method that, in theory, is supposed to return all the headers, but it always returns null.
+     * On the other hand, the 'getHeader' method works fine, but it only returns one header at a time, and you have to pass the header name as a parameter.
+     *
+     * @return array An array of request headers in the format (key, value).
+     */
+    protected function getRequestHeaders()
+    {
+        $headers = []; // (key, value) array
+        foreach (self::REQUEST_HEADERS as $header) {
+            $value = $this->request->getHeader($header, false);
+            if ($value !== false) { // if header exists
+                $headers[$header] = $value;
+            }
+        }
+        return $headers;
+    }
+
+    /**
+     * Returns an array of request headers in the format expected by cURL.
+     *
+     * cURL expects headers to be a list of strings in the format 'header-name: header-value, header-value, ...'
+     *
+     * @param array $headers An array of request headers in the format (key, value).
+     * @return array An array of request headers in the format expected by cURL.
+     */
+    protected function mapHeaderKeysCurl(array $headers)
+    {
+        return array_map(function ($key, $value) {
+            return $key . ': ' . $value;
+        }, array_keys($headers), $headers);
+    }
+
+
+    /**
+     * Processes a single response header from a cURL request and adds it to an array of response headers.
+     *
+     * This function is called by cURL for each header received in the response. It parses the header string into a key-value pair and adds it to the $response_headers array.
+     *
+     * @param mixed $curl The cURL handle.
+     * @param string $header The header string received from the server.
+     * @param array $response_headers An array of response headers in the format (key, value).
+     * @return int The number of bytes read from the header string (used by cURL as a pointer).
+     */
+    function processResponseHeader($curl, string $header, array &$response_headers)
+    {
+        $this->logger->info('curl object: ' . get_class($curl));
+        $len = strlen($header);
+        $header = explode(':', $header, 2);
+        if (count($header) < 2) // ignore invalid headers
+            return $len; // number of bytes read (used by curl as a pointer)
+        if (isset($response_headers[trim($header[0])])) {
+            $response_headers[trim($header[0])] = $response_headers[trim($header[0])] . ', ' . trim($header[1]);
+        } else {
+            $response_headers[trim($header[0])] = trim($header[1]);
+        }
+        return $len; // number of bytes read
+    }
+}

--- a/Northbeam/PixelForwarder/Model/Forwarder.php
+++ b/Northbeam/PixelForwarder/Model/Forwarder.php
@@ -91,6 +91,7 @@ class Forwarder implements ForwarderInterface
     {
         $headers = []; // (key, value) array
         $headers['content-length'] = $content_length;
+        $headers['X-Nb-Proxy'] = 'nb-magento/1.1.0'; // this header is used to identify requests proxied by this module
         foreach (self::REQUEST_HEADERS as $header) {
             $value = $this->request->getHeader($header, false);
             if ($value !== false) { // if header exists

--- a/Northbeam/PixelForwarder/etc/di.xml
+++ b/Northbeam/PixelForwarder/etc/di.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" ?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <preference
+        for="Northbeam\PixelForwarder\Api\ForwarderInterface"
+        type="Northbeam\PixelForwarder\Model\Forwarder"
+    />
+</config>

--- a/Northbeam/PixelForwarder/etc/module.xml
+++ b/Northbeam/PixelForwarder/etc/module.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
+    <module name="Northbeam_PixelForwarder">
+        <sequence>
+            <module name="Magento_Webapi" />
+        </sequence>
+    </module>
+</config>

--- a/Northbeam/PixelForwarder/etc/webapi.xml
+++ b/Northbeam/PixelForwarder/etc/webapi.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<routes xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Webapi:etc/webapi.xsd">
+    <route url="/nb-collector" method="POST">
+        <service class="Northbeam\PixelForwarder\Api\ForwarderInterface" method="proxy" />
+        <resources>
+            <resource ref="anonymous"/>
+        </resources>
+    </route>
+</routes>

--- a/Northbeam/PixelForwarder/etc/webapi_rest/di.xml
+++ b/Northbeam/PixelForwarder/etc/webapi_rest/di.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <type name="Magento\Webapi\Controller\Rest\RequestProcessorPool">
+        <arguments>
+            <argument name="requestProcessors" xsi:type="array">
+                <item name="sync" xsi:type="object">Northbeam\PixelForwarder\Controller\PixelRequestProcessor</item>
+            </argument>
+        </arguments>
+    </type>
+</config>

--- a/Northbeam/PixelForwarder/registration.php
+++ b/Northbeam/PixelForwarder/registration.php
@@ -1,0 +1,6 @@
+<?php
+\Magento\Framework\Component\ComponentRegistrar::register(
+    \Magento\Framework\Component\ComponentRegistrar::MODULE,
+    'Northbeam_PixelForwarder',
+    __DIR__
+);

--- a/composer.json
+++ b/composer.json
@@ -8,9 +8,10 @@
       "php": "~7.4.0||~8.2.0"
     },
     "autoload": {
-      "files": [ "registration.php" ],
+      "files": [ "registration.php", "Northbeam/PixelForwarder/registration.php" ],
       "psr-4": {
-        "Northbeam\\OrderTracking\\": ""
+        "Northbeam\\OrderTracking\\": "",
+        "Northbeam\\PixelForwarder\\": "Northbeam/PixelForwarder"
       }
     }
   }

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "version": "1.0.0",
     "license": "proprietary",
     "require": {
-      "php": "~7.4.0||~8.1.0"
+      "php": "~7.4.0||~8.2.0"
     },
     "autoload": {
       "files": [ "registration.php" ],

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "northbeam/integration",
     "description": "NB integration module",
     "type": "magento2-module",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "license": "proprietary",
     "require": {
       "php": "~7.4.0||~8.2.0"


### PR DESCRIPTION
## Changes
The changes enable us to create a custom route that acts as an intermediary for passing events from the Northbeam Pixel to the Northbeam Snowplow Collector. This modification is important as it will allow us to more accurately and effectively track and analyze user behavior on our website. By using this proxying mechanism, we can ensure that we address the new iOS 16.4 cookie limitations effectively.

More details in the [Woo Commerce / Magento / iOS 16.4 Integration](https://www.notion.so/northbeaminc/Woo-Commerce-Magento-iOS-16-4-Integration-550a720a1f474bab92442bfe10dce99b) project page.

## Tests
Tests evidence and conclusions are present in [here](https://www.notion.so/northbeaminc/Magento-Modify-plugin-to-proxy-the-events-613ab050e7b146e1af8b443ad460bc67?pvs=4)