### PR TITLE
Update csp_whitelist.xml

### DIFF
--- a/etc/csp_whitelist.xml
+++ b/etc/csp_whitelist.xml
@@ -3,12 +3,12 @@
     <policies>
         <policy id="script-src">
             <values>
-                <value id="nb-pixel-script" type="host">*</value>
+                <value id="nb-pixel-script" type="host">*.northbeam.io</value>
             </values>
         </policy>
         <policy id="connect-src">
             <values>
-                <value id="nb-pixel-connect" type="host">*</value>
+                <value id="nb-pixel-connect" type="host">*.northbeam.io</value>
             </values>
         </policy>
     </policies>


### PR DESCRIPTION
Please set legitimate Content Security Policy values for yourself. By having `*` as the value, you are opening up your clients to potential security vulnerabilities.